### PR TITLE
Add Manual approval stage with manual approval comments and url

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -1,7 +1,7 @@
 module "service_catalog_deployment_pipeline" {
   source                  = "../module/"
   template_bucket         = aws_s3_bucket.template_store
-  template_key            = aws_s3_object.template.key
+  template_zip_object     = aws_s3_object.template
   template_path           = basename(data.archive_file.template.source_file)
   service_catalog_product = aws_servicecatalog_product.template
 }

--- a/module/main.tf
+++ b/module/main.tf
@@ -1,5 +1,9 @@
 data "aws_caller_identity" "current" {}
 
 locals {
+  # Common Resource Name so name can be changed centrally much easier
   common_resource_name = "sc-pipeline-${data.aws_caller_identity.current.account_id}"
+
+  # Automatically fill manual_approval_url with S3 Bucket URL
+  manual_approval_url = var.manual_approval_url == "" ? "https://terraform-20221003110118004900000002.s3.eu-west-1.amazonaws.com/example-ec2.zip" : var.manual_approval_url
 }

--- a/module/main.tf
+++ b/module/main.tf
@@ -5,5 +5,5 @@ locals {
   common_resource_name = "sc-pipeline-${data.aws_caller_identity.current.account_id}"
 
   # Automatically fill manual_approval_url with S3 Bucket URL
-  manual_approval_url = var.manual_approval_url == "" ? "https://terraform-20221003110118004900000002.s3.eu-west-1.amazonaws.com/example-ec2.zip" : var.manual_approval_url
+  manual_approval_url = var.manual_approval_url == "" ? "https://s3.console.aws.amazon.com/s3/buckets/${var.template_bucket.bucket}" : var.manual_approval_url
 }

--- a/module/pipeline.tf
+++ b/module/pipeline.tf
@@ -20,7 +20,7 @@ resource "aws_codepipeline" "codepipeline" {
 
       configuration = {
         S3Bucket             = var.template_bucket.bucket
-        S3ObjectKey          = var.template_key
+        S3ObjectKey          = var.template_zip_object.key
         PollForSourceChanges = true
       }
     }
@@ -40,6 +40,22 @@ resource "aws_codepipeline" "codepipeline" {
       configuration = {
         ProjectName   = aws_codebuild_project.static_tests.name
         PrimarySource = "source_output"
+      }
+    }
+  }
+
+  stage {
+    name = "Approval"
+
+    action {
+      name     = "manual-approval"
+      category = "Approval"
+      owner    = "AWS"
+      provider = "Manual"
+      version  = "1"
+      configuration = {
+        "CustomData"         = var.manual_approval_comments
+        "ExternalEntityLink" = local.manual_approval_url
       }
     }
   }

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -1,9 +1,8 @@
 variable "template_bucket" {
   description = "S3 Bucket resource where the template is stored"
   type = object({
-    arn                = string
-    bucket             = string
-    bucket_domain_name = string
+    arn    = string
+    bucket = string
   })
 }
 

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -1,18 +1,21 @@
 variable "template_bucket" {
   description = "S3 Bucket resource where the template is stored"
   type = object({
-    arn    = string
-    bucket = string
+    arn                = string
+    bucket             = string
+    bucket_domain_name = string
   })
 }
 
-variable "template_key" {
-  description = "Key to the zipped template object in S3"
-  type        = string
+variable "template_zip_object" {
+  description = "Zipped template object in S3"
+  type = object({
+    key = string
+  })
 
   validation {
-    condition     = endswith(var.template_key, ".zip")
-    error_message = "The template_key value must be a compressed file ending with \".zip\"."
+    condition     = endswith(var.template_zip_object.key, ".zip")
+    error_message = "The template_zip_object.key value must be a compressed file ending with \".zip\"."
   }
 }
 
@@ -32,4 +35,16 @@ variable "service_catalog_product" {
     arn = string
     id  = string
   })
+}
+
+variable "manual_approval_comments" {
+  description = "The comments displayed to the user when manual approval is needed"
+  type        = string
+  default     = "A review is needed for deploying this service catalog product"
+}
+
+variable "manual_approval_url" {
+  description = "The url you want to provide to the user as part of the approval request"
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
This adds a manual approval stage just before deployment.

This will stop automatic overwriting of the service catalog product, when people are not ready for a full deployment.

Fixes #5 