### PR TITLE
Optional approvals

### DIFF
--- a/example/main.tf
+++ b/example/main.tf
@@ -4,4 +4,5 @@ module "service_catalog_deployment_pipeline" {
   template_zip_object     = aws_s3_object.template
   template_path           = basename(data.archive_file.template.source_file)
   service_catalog_product = aws_servicecatalog_product.template
+  manual_approval_enabled = true
 }

--- a/module/main.tf
+++ b/module/main.tf
@@ -6,4 +6,6 @@ locals {
 
   # Automatically fill manual_approval_url with S3 Bucket URL
   manual_approval_url = var.manual_approval_url == "" ? "https://s3.console.aws.amazon.com/s3/buckets/${var.template_bucket.bucket}" : var.manual_approval_url
+
+  approval = var.manual_approval_enabled ? [local.manual_approval_url] : []
 }

--- a/module/main.tf
+++ b/module/main.tf
@@ -7,5 +7,7 @@ locals {
   # Automatically fill manual_approval_url with S3 Bucket URL
   manual_approval_url = var.manual_approval_url == "" ? "https://s3.console.aws.amazon.com/s3/buckets/${var.template_bucket.bucket}" : var.manual_approval_url
 
+  # A work around to use an "if" statement within the manual approval action allowing
+  # user to decide if they want to enable manual approval or not.
   approval = var.manual_approval_enabled ? [local.manual_approval_url] : []
 }

--- a/module/pipeline.tf
+++ b/module/pipeline.tf
@@ -44,18 +44,21 @@ resource "aws_codepipeline" "codepipeline" {
     }
   }
 
-  stage {
-    name = "Approval"
+  dynamic "stage" {
+    for_each = local.approval
+    content {
+      name = "Approval"
 
-    action {
-      name     = "manual-approval"
-      category = "Approval"
-      owner    = "AWS"
-      provider = "Manual"
-      version  = "1"
-      configuration = {
-        "CustomData"         = var.manual_approval_comments
-        "ExternalEntityLink" = local.manual_approval_url
+      action {
+        name     = "manual-approval"
+        category = "Approval"
+        owner    = "AWS"
+        provider = "Manual"
+        version  = "1"
+        configuration = {
+          "CustomData"         = var.manual_approval_comments
+          "ExternalEntityLink" = stage.value
+        }
       }
     }
   }

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -36,6 +36,12 @@ variable "service_catalog_product" {
   })
 }
 
+variable "manual_approval_enabled" {
+  description = "Enable manual approval within the pipeline stages."
+  type        = bool
+  default     = false
+}
+
 variable "manual_approval_comments" {
   description = "The comments displayed to the user when manual approval is needed"
   type        = string

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -43,13 +43,13 @@ variable "manual_approval_enabled" {
 }
 
 variable "manual_approval_comments" {
-  description = "The comments displayed to the user when manual approval is needed"
+  description = "(Ignore if manual approval is disabled) The comments displayed to the user when manual approval is needed"
   type        = string
   default     = "A review is needed for deploying this service catalog product"
 }
 
 variable "manual_approval_url" {
-  description = "The url you want to provide to the user as part of the approval request"
+  description = "(Ignore if manual approval is disabled) The url you want to provide to the user as part of the approval request"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Fixes #13 

This adds a variable called "manual_approval_enabled" which is a boolean that determines wether manual approval is wanted within the pipeline before deploying to production.